### PR TITLE
Handle errors during `getLinks` parsing

### DIFF
--- a/src/links.ts
+++ b/src/links.ts
@@ -183,10 +183,14 @@ export async function getLinks(
 		},
 	});
 	await new Promise((resolve, reject) => {
-		Stream.Readable.fromWeb(source as import('stream/web').ReadableStream)
-			.pipe(parser)
-			.on('finish', resolve)
-			.on('error', reject);
+		const rs = Stream.Readable.fromWeb(
+			source as import('stream/web').ReadableStream,
+		);
+
+		// Reject on Readable error
+		rs.on('error', reject);
+
+		rs.pipe(parser).on('finish', resolve).on('error', reject);
 	});
 	return links;
 }

--- a/test/test.index.ts
+++ b/test/test.index.ts
@@ -8,6 +8,7 @@ import {
 	LinkState,
 	check,
 } from '../src/index.js';
+import * as linksMethods from '../src/links.ts';
 import { DEFAULT_OPTIONS } from '../src/options.ts';
 import { invertedPromise } from './utils.ts';
 
@@ -627,6 +628,25 @@ describe('linkinator', () => {
 		});
 		assert.ok(results.passed);
 		scope.done();
+	});
+
+	it('should treat link as broken when getLinks throws', async () => {
+		const parseErr = new Error('Parsing failure');
+		const spy = vi.spyOn(linksMethods, 'getLinks').mockRejectedValue(parseErr);
+
+		const checker = new LinkChecker();
+		const results = await checker.check({
+			path: 'test/fixtures/basic',
+		});
+
+		assert.ok(!results.passed);
+		assert.strictEqual(results.links[0].state, LinkState.BROKEN);
+		assert.strictEqual(
+			(results.links[0]?.failureDetails?.[0] as Error).message,
+			'Parsing failure',
+		);
+
+		spy.mockRestore();
 	});
 
 	describe('element metadata', () => {

--- a/test/test.links.ts
+++ b/test/test.links.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { getLinks } from '../src/links.js';
+
+describe('getLinks', () => {
+	it('should reject when the HTML stream emits an error', async () => {
+		const body = new ReadableStream({
+			start(controller) {
+				setTimeout(() => controller.error(new Error('StreamError')), 0);
+			},
+		});
+
+		const response = {
+			body,
+			headers: new Headers({ 'content-type': 'text/html' }),
+		} as unknown as Response;
+
+		// Expect getLinks to reject with our error,
+		await expect(getLinks(response, 'http://example.invalid')).rejects.toThrow(
+			'StreamError',
+		);
+	});
+});


### PR DESCRIPTION
In some cases, `DOMException [TimeoutError]: The operation was aborted due to timeout` is shown and crashes the process. This seems to originate from the link parsing in `getLinks`.

* add error handler to the `Readable` stream to reject the promise
* catch error during `getLinks` parsing and treat it as a broken link